### PR TITLE
Build: separate another `codecov` job to `ci` github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-#    types:
-#      - closed
     branches:
       - main
 
@@ -19,8 +17,7 @@ env:
   LDFLAGS: "--coverage"
 
 jobs:
-  build:
-#    if: github.event.pull_request.merged == true || github.event_name == 'push'
+  build-and-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -93,6 +90,25 @@ jobs:
           lcov --capture --directory . --output-file coverage.info
           lcov --remove coverage.info '/usr/*' --output-file coverage.info
           lcov --list coverage.info
+
+      - name: Upload Coverage Info
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-info
+          path: ${{ steps.strings.outputs.build-output-dir }}/coverage.info
+
+  codecov:
+    needs: build-and-test
+    if: github.event.pull_request.merged == true || github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Coverage Info
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-info
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved CI workflow by removing unnecessary commented-out code.
  - Enhanced job execution logic for better efficiency.
  - Added steps to upload and download coverage information for better tracking and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->